### PR TITLE
sys.executable as Python binary + fixes in action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,31 +3,31 @@ description: "Installs dependencies and runs common Python linters"
 inputs:
   source:
     description: 'Source directory'
-    required: true
+    required: false
   python-version:
     description: "What Python version use for running linting tools"
     required: false
-    default: 3.8
+    default: '3.8'
   use-isort:
     description: "Run isort check"
     required: false
-    default: true
+    default: 'true'
   use-black:
     description: "Run black check"
     required: false
-    default: true
+    default: 'true'
   use-flake8:
     description: "Run flake8 check"
     required: false
-    default: true
+    default: 'true'
   use-mypy:
     description: "Run mypy check"
     required: false
-    default: true
+    default: 'true'
   install-requirements:
     description: "Install dependencies from requirements.txt (for type checking)"
     required: false
-    default: true
+    default: 'true'
   extra-requirements:
     description: "Install extra dependencies (type stubs, extensions etc.)"
     required: false
@@ -40,6 +40,9 @@ runs:
       with:
         python-version: ${{inputs.python-version}}
     - run: pip install lint-python==2.0.0
+      shell: bash
+    - run: pip install -r requirements.txt
+      if: ${{inputs.install-requirements == 'true'}}
       shell: bash
     - run: lint-python --check --install
       shell: bash


### PR DESCRIPTION
- Invoked python is still got from $PATH, we should use `sys.executable` to ensure we're in venv. It's easier to use if you can't activate environment properly.

> You don’t specifically need to activate an environment; activation just prepends the virtual environment’s binary directory to your path, so that “python” invokes the virtual environment’s Python interpreter and you can run installed scripts without having to use their full path. However, all scripts installed in a virtual environment should be runnable without activating it, and run with the virtual environment’s Python automatically.

- Added missing parts of an actual Github Action