### PR TITLE
CI: Upgrade checkout and setup-python actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   release_pypi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build package
       run: |
         pip3 install build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - run: pip install .

--- a/action.yml
+++ b/action.yml
@@ -35,8 +35,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{inputs.python-version}}
     - run: pip install lint-python==2.0.0


### PR DESCRIPTION
Current actions versions are using deprecated features:
![image](https://user-images.githubusercontent.com/8720367/229540088-595783dc-1196-494d-a2c0-b3eb7b99218a.png)
