### PR TITLE
Fix: correctly handle source directory param

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,7 @@ inputs:
   source:
     description: 'Source directory'
     required: false
+    default: '.'
   python-version:
     description: "What Python version use for running linting tools"
     required: false
@@ -42,9 +43,11 @@ runs:
     - run: pip install lint-python==2.0.0
       shell: bash
     - run: pip install -r requirements.txt
+      working-directory: ${{inputs.source}}
       if: ${{inputs.install-requirements == 'true'}}
       shell: bash
     - run: lint-python --check --install
+      working-directory: ${{inputs.source}}
       shell: bash
 branding:
   color: "green"


### PR DESCRIPTION
`source` should be used when we have multiple Python projects within repository and we want to run action on specific one