### PR TITLE
Revert "Fix: correctly handle source directory param"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,6 @@ inputs:
   source:
     description: 'Source directory'
     required: false
-    default: '.'
   python-version:
     description: "What Python version use for running linting tools"
     required: false
@@ -43,11 +42,9 @@ runs:
     - run: pip install lint-python==2.0.0
       shell: bash
     - run: pip install -r requirements.txt
-      working-directory: ${{inputs.source}}
       if: ${{inputs.install-requirements == 'true'}}
       shell: bash
     - run: lint-python --check --install
-      working-directory: ${{inputs.source}}
       shell: bash
 branding:
   color: "green"


### PR DESCRIPTION
Reverts CERT-Polska/lint-python-action#7

Actually `source` is respected by `lint-python` itself and #7 breaks the original behavior. We probably need another parameter that will allow to support multiple Python projects contained in single repository.